### PR TITLE
Add --expression to the yq command extracting versions from Charts

### DIFF
--- a/scripts/detect_changed_charts.sh
+++ b/scripts/detect_changed_charts.sh
@@ -70,8 +70,8 @@ for CHART_PATH in $CHANGED_CHARTS; do
         continue
     fi
 
-    CHART_NAME=$(yq e .name "$CHART_YAML_PATH")
-    CHART_VERSION=$(yq e .version "$CHART_YAML_PATH")
+    CHART_NAME=$(yq e --expression .name "$CHART_YAML_PATH")
+    CHART_VERSION=$(yq e --expression .version "$CHART_YAML_PATH")
     EXPECTED_GIT_TAG="$CHART_NAME-$CHART_VERSION"
     EXPECTED_GIT_TAG_EXISTS="false"
 


### PR DESCRIPTION
### Summary and Scope

EXPLAIN WHY THIS PR IS NECESSARY. WHAT IS IMPACTED?
IS THIS A NEW FEATURE OR CRITICAL BUG FIX? SUMMARIZE WHAT CHANGED.
This is to fix an edge case for an unsupported configuration of the HMS build infrastructure when a repo builds a chart and image from the same repo. There is a `.version` file that is used by the image building workflows that confuses the yq commands in detect_changed_charts and outputs the wrong information, as it believes 2 files has been passed to it instead of an expression and file.

Here is what happens without this fix:
```
[~/Documents/Github/cray-nls]$ ./hms-build-changed-charts-action/scripts/detect_changed_charts.sh ./charts master | jq
Target branch:  master
Current Branch: master
Fetching tags
Current and target branches are the same!
Charts to consider: ./charts/v1.0/cray-iuf
./charts/v1.0/cray-nls
Checking changed chart: ./charts/v1.0/cray-iuf
{
  "Path": "./charts/v1.0/cray-iuf",
  "Name": "cray-iuf",
  "Version": "0.9.11\n---\n#\n# MIT License\n#\n# (C) Copyright [2022] Hewlett Packard Enterprise Development LP\n#\n# Permission is hereby granted, free of charge, to any person obtaining a\n# copy of this software and associated documentation files (the \"Software\"),\n# to deal in the Software without restriction, including without limitation\n# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n# and/or sell copies of the Software, and to permit persons to whom the\n# Software is furnished to do so, subject to the following conditions:\n#\n# The above copyright notice and this permission notice shall be included\n# in all copies or substantial portions of the Software.\n#\n# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR\n# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,\n# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR\n# OTHER DEALINGS IN THE SOFTWARE.\n#\napiVersion: v2\nname: \"cray-iuf\"\nversion: 0.0.2\ndescription: \"Kubernetes resources for cray-nls\"\nhome: \"https://github.com/Cray-HPE/cray-nls/charts/v1.0/cray-iuf\"\nsources:\n  - \"https://github.com/Cray-HPE/cray-nls\"\ndependencies:\n  - name: metacontroller-helm\n    version: \"v4.4.0\"\n    repository: \"https://artifactory.algol60.net/artifactory/csm-helm-charts\"\nmaintainers:\n  - name: Platform Engineering\n    url: https://github.com/orgs/Cray-HPE/teams/platform-engineering\nappVersion: \"0.0.1\"\nannotations:\n  artifacthub.io/license: \"MIT\"",
  "ExpectedGitTag": "cray-iuf-0.9.11\n---\n#\n# MIT License\n#\n# (C) Copyright [2022] Hewlett Packard Enterprise Development LP\n#\n# Permission is hereby granted, free of charge, to any person obtaining a\n# copy of this software and associated documentation files (the \"Software\"),\n# to deal in the Software without restriction, including without limitation\n# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n# and/or sell copies of the Software, and to permit persons to whom the\n# Software is furnished to do so, subject to the following conditions:\n#\n# The above copyright notice and this permission notice shall be included\n# in all copies or substantial portions of the Software.\n#\n# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR\n# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,\n# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR\n# OTHER DEALINGS IN THE SOFTWARE.\n#\napiVersion: v2\nname: \"cray-iuf\"\nversion: 0.0.2\ndescription: \"Kubernetes resources for cray-nls\"\nhome: \"https://github.com/Cray-HPE/cray-nls/charts/v1.0/cray-iuf\"\nsources:\n  - \"https://github.com/Cray-HPE/cray-nls\"\ndependencies:\n  - name: metacontroller-helm\n    version: \"v4.4.0\"\n    repository: \"https://artifactory.algol60.net/artifactory/csm-helm-charts\"\nmaintainers:\n  - name: Platform Engineering\n    url: https://github.com/orgs/Cray-HPE/teams/platform-engineering\nappVersion: \"0.0.1\"\nannotations:\n  artifacthub.io/license: \"MIT\"",
  "ExpectedGitTagExists": false
}
Checking changed chart: ./charts/v1.0/cray-nls
{
  "Path": "./charts/v1.0/cray-nls",
  "Name": "cray-nls",
  "Version": "0.9.11\n---\n#\n# MIT License\n#\n# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP\n#\n# Permission is hereby granted, free of charge, to any person obtaining a\n# copy of this software and associated documentation files (the \"Software\"),\n# to deal in the Software without restriction, including without limitation\n# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n# and/or sell copies of the Software, and to permit persons to whom the\n# Software is furnished to do so, subject to the following conditions:\n#\n# The above copyright notice and this permission notice shall be included\n# in all copies or substantial portions of the Software.\n#\n# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR\n# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,\n# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR\n# OTHER DEALINGS IN THE SOFTWARE.\n#\napiVersion: v2\nname: \"cray-nls\"\nversion: 1.4.43\ndescription: \"Kubernetes resources for cray-nls\"\nhome: \"https://github.com/Cray-HPE/cray-nls-charts\"\nsources:\n  - \"https://github.com/Cray-HPE/cray-nls\"\ndependencies:\n  - name: cray-service\n    version: ~8.2.0\n    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts\n    alias: cray-service-pg-only\n  - name: cray-service\n    version: ~8.2.0\n    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts\n    alias: cray-service\n  - name: argo-workflows\n    # TODO: point to Alex argo workflow repo\n    # When his PR is merged\n    version: \"0.16.2\"\n    repository: https://argoproj.github.io/argo-helm\nmaintainers:\n  - name: Platform Engineering\n    url: https://github.com/orgs/Cray-HPE/teams/platform-engineering\nappVersion: \"0.0.1\"\nannotations:\n  artifacthub.io/license: \"MIT\"",
  "ExpectedGitTag": "cray-nls-0.9.11\n---\n#\n# MIT License\n#\n# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP\n#\n# Permission is hereby granted, free of charge, to any person obtaining a\n# copy of this software and associated documentation files (the \"Software\"),\n# to deal in the Software without restriction, including without limitation\n# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n# and/or sell copies of the Software, and to permit persons to whom the\n# Software is furnished to do so, subject to the following conditions:\n#\n# The above copyright notice and this permission notice shall be included\n# in all copies or substantial portions of the Software.\n#\n# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR\n# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,\n# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR\n# OTHER DEALINGS IN THE SOFTWARE.\n#\napiVersion: v2\nname: \"cray-nls\"\nversion: 1.4.43\ndescription: \"Kubernetes resources for cray-nls\"\nhome: \"https://github.com/Cray-HPE/cray-nls-charts\"\nsources:\n  - \"https://github.com/Cray-HPE/cray-nls\"\ndependencies:\n  - name: cray-service\n    version: ~8.2.0\n    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts\n    alias: cray-service-pg-only\n  - name: cray-service\n    version: ~8.2.0\n    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts\n    alias: cray-service\n  - name: argo-workflows\n    # TODO: point to Alex argo workflow repo\n    # When his PR is merged\n    version: \"0.16.2\"\n    repository: https://argoproj.github.io/argo-helm\nmaintainers:\n  - name: Platform Engineering\n    url: https://github.com/orgs/Cray-HPE/teams/platform-engineering\nappVersion: \"0.0.1\"\nannotations:\n  artifacthub.io/license: \"MIT\"",
  "ExpectedGitTagExists": false
}
```

With fix
```
[~/Documents/Github/cray-nls]$ ./hms-build-changed-charts-action/scripts/detect_changed_charts.sh ./charts master | jq
Target branch:  master
Current Branch: master
Fetching tags
Current and target branches are the same!
Charts to consider: ./charts/v1.0/cray-iuf
./charts/v1.0/cray-nls
Checking changed chart: ./charts/v1.0/cray-iuf
{
  "Path": "./charts/v1.0/cray-iuf",
  "Name": "cray-iuf",
  "Version": "0.0.2",
  "ExpectedGitTag": "cray-iuf-0.0.2",
  "ExpectedGitTagExists": true
}
Checking changed chart: ./charts/v1.0/cray-nls
{
  "Path": "./charts/v1.0/cray-nls",
  "Name": "cray-nls",
  "Version": "1.4.43",
  "ExpectedGitTag": "cray-nls-1.4.43",
  "ExpectedGitTagExists": false
}
```
### Risks and Mitigations

Low risk